### PR TITLE
Handling derived empty clauses

### DIFF
--- a/cleanup.c
+++ b/cleanup.c
@@ -16,7 +16,6 @@ int isSatisfied (int *clause) {
   return 0; }
 
 int removeFalsified (int *clause, int index) {
-
   int count = 0;
   int *_clause = clause;
   int flag = 0;
@@ -44,12 +43,12 @@ int removeFalsified (int *clause, int index) {
         clause++; }
       fprintf (lrat, "%i 0\n", cIndex[index]);
       clause = _clause;
-      if (empty) {
-        foundEmptyClause = 1;
-        return 1; }
 
       fprintf (lrat, "%i d %i 0\n", max, cIndex[index]);
       cIndex[index] = max;
+      if (empty) {
+        foundEmptyClause = 1;
+        return 1; }
     }
   }
 
@@ -225,6 +224,11 @@ int main (int argc, char** argv) {
   nCls = j;
 */
 
+  if (foundEmptyClause) {
+    printf("p cnf 1 1\n0\n");
+    return 20;
+  }
+
   int nTaut = 0;
   for (int i = 0; i < nCls; i++)
     if (isTautology (table + cls[i]))
@@ -238,11 +242,6 @@ int main (int argc, char** argv) {
     for (int i = 0; i < nSatis; i++)
       fprintf (lrat, "%i ", satis[i]);
     fprintf (lrat, "0\n");
-  }
-
-  if (foundEmptyClause) {
-    printf("p cnf 1 1\n0\n");
-    return 20;
   }
 
   printf("p cnf %i %i\n", nVar, nCls - nTaut);

--- a/cleanup.c
+++ b/cleanup.c
@@ -6,6 +6,7 @@
 FILE* lrat = NULL;
 
 int *mask, *vIndex, *cIndex, stamp = 0, max;
+int foundEmptyClause = 0;
 
 int isSatisfied (int *clause) {
   if (clause[1] == 0) return 0;
@@ -15,6 +16,7 @@ int isSatisfied (int *clause) {
   return 0; }
 
 int removeFalsified (int *clause, int index) {
+
   int count = 0;
   int *_clause = clause;
   int flag = 0;
@@ -28,9 +30,11 @@ int removeFalsified (int *clause, int index) {
 
     if (flag) {
       fprintf (lrat, "%i ", ++max);
+      int empty = 1;
       while (*clause) {
-        if (mask[-*clause] != stamp)
+        if (mask[-*clause] != stamp) {
           fprintf (lrat, "%i ", *clause);
+          empty = 0; }
         clause++; }
       fprintf (lrat, "0 ");
       clause = _clause;
@@ -40,6 +44,9 @@ int removeFalsified (int *clause, int index) {
         clause++; }
       fprintf (lrat, "%i 0\n", cIndex[index]);
       clause = _clause;
+      if (empty) {
+        foundEmptyClause = 1;
+        return 1; }
 
       fprintf (lrat, "%i d %i 0\n", max, cIndex[index]);
       cIndex[index] = max;
@@ -158,8 +165,10 @@ int main (int argc, char** argv) {
         mask[ table[cls[i]] ] = stamp; }
       if (removeFalsified (table + cls[i], i)) iter = 1;
       cIndex[j] = cIndex[i];
-      cls[j++] = cls[i]; }
-    nCls = j; }
+      cls[j++] = cls[i];
+      if (foundEmptyClause) break; }
+    nCls = j;
+    if (foundEmptyClause) break; }
 
 /*
   // active, length, occ, list
@@ -231,14 +240,14 @@ int main (int argc, char** argv) {
     fprintf (lrat, "0\n");
   }
 
-  int unsat = 0;
+  if (foundEmptyClause) {
+    printf("p cnf 1 1\n0\n");
+    return 20;
+  }
 
   printf("p cnf %i %i\n", nVar, nCls - nTaut);
   for (int i = 0; i < nCls; i++) {
     if (!isTautology (table + cls[i]))
-      if (table[cls[i]] == 0) {
-//        printf ("c found empty clause\n");
-        unsat = 1; }
       printClause (table + cls[i]); }
 
   if (map != NULL) {
@@ -247,6 +256,5 @@ int main (int argc, char** argv) {
         if (cIndex[i] != i+1)
           fprintf (map, "%i %i\n", i+1, cIndex[i]); }
 
-  if (unsat) return 20;
   return 0;
 }


### PR DESCRIPTION
The current implementation leads to what seems to be an erroneous proof (via `lrat-check`) for this example:
```
p cnf 1 2
1 0
-1 0
```
Rather than checking for empty clauses in the preprocessed formula, I suggest to check for empty clauses while outputting LRAT lines. If an empty clause is found, preprocessing can be interrupted. In this case a trivially unsatisfiable formula and an empty map file are output.

I confirmed that this results in a verifiable proof for the above example as well as for `UNSAT_H_instances_childsnack_p12.hddl_1.cnf` (the huge trivial formula we had problems with). I also did a basic test on a formula which doesn't lead to UNSAT in the preprocessor. 

Perhaps you could also take a quick look at the changes and see if they make sense to you too? Thanks!